### PR TITLE
Valuetransformer variable defaults

### DIFF
--- a/plugins/beeper.com/v1/valuetransformer/util.go
+++ b/plugins/beeper.com/v1/valuetransformer/util.go
@@ -201,6 +201,11 @@ func transformInterface(i interface{}, transforms []Transform, path string) inte
 
 				repl, foundRepl := transform.source[matches[1]]
 
+				if !foundRepl && len(matches) > 2 && len(matches[2]) > 0 {
+					repl = matches[3]
+					foundRepl = true
+				}
+
 				// update matched state for string if it doesn't exist or we found
 				matched, havePrevMatch := transform.match[matches[0]]
 				if !havePrevMatch || (foundRepl && !matched) {
@@ -272,7 +277,8 @@ func applyTransforms(resource map[string]interface{}, config *TransformerConfig,
 
 		var regex *regexp.Regexp
 		if t.Regex == "" {
-			regex = regexp.MustCompile(`\${([^}]*)}`)
+			// Groups are: (sourceKey) (defaultEnabledFlag :) (defaultValue)
+			regex = regexp.MustCompile(`\${([^}:]*)(:?)([^}:]*)}`)
 		} else {
 			regex = regexp.MustCompile(t.Regex)
 		}

--- a/plugins/beeper.com/v1/valuetransformer/util.go
+++ b/plugins/beeper.com/v1/valuetransformer/util.go
@@ -199,15 +199,15 @@ func transformInterface(i interface{}, transforms []Transform, path string) inte
 					return sk
 				}
 
-				repl, ok := transform.source[matches[1]]
+				repl, foundRepl := transform.source[matches[1]]
 
 				// update matched state for string if it doesn't exist or we found
-				matched, mok := transform.match[matches[0]]
-				if !mok || (ok && !matched) {
-					transform.match[matches[0]] = ok
+				matched, havePrevMatch := transform.match[matches[0]]
+				if !havePrevMatch || (foundRepl && !matched) {
+					transform.match[matches[0]] = foundRepl
 				}
 
-				if !ok {
+				if !foundRepl {
 					return sk
 				}
 


### PR DESCRIPTION
Enables doing `${SOURCEKEY:DEFAULT}` style replacements to stop scary looking error logs where values are not expected to always be replaced.